### PR TITLE
chore: pin GitHub Actions to latest release SHAs

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -24,28 +24,28 @@ jobs:
       !github.event.pull_request.draft
     steps:
       - name: Clone Repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: '3.11'
 
       - name: Load cached .local
-        uses: actions/cache@v4
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.local
           key: dotlocal
 
       - name: Install Poetry
-        uses: snok/install-poetry@v1
+        uses: snok/install-poetry@a783c322200f0519c7926aa6faa857c4e23e9263 # v1.4.2
         with:
           virtualenvs-create: true
           virtualenvs-in-project: true
 
       - name: Load Cached Venv
         id: cached-poetry-dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: .venv
           key: venv-${{ hashFiles(env.CACHE_FILE) }}
@@ -54,7 +54,7 @@ jobs:
         run: poetry install --sync
 
       - name: Run Benchmarks
-        uses: CodSpeedHQ/action@v4
+        uses: CodSpeedHQ/action@4296e51e7041e24dadb86d1d6e8b9320d223dbe8 # v5.0.3
         with:
           token: ${{ secrets.CODSPEED_TOKEN }}
           run: poetry run pytest --codspeed -v


### PR DESCRIPTION


---



- d415177 | chore: pin GitHub Actions to latest release SHAs
